### PR TITLE
ansible-operator: add nextcloud role and setup instructions

### DIFF
--- a/07_ansible_operator/.gitignore
+++ b/07_ansible_operator/.gitignore
@@ -1,0 +1,2 @@
+hosts
+*.retry

--- a/07_ansible_operator/README.org
+++ b/07_ansible_operator/README.org
@@ -1,0 +1,36 @@
+* Ansible Operator workshop
+** Prerequisites
+
+- Download ansible role
+  - ~git clone git@github.com:prgcont/ansible-nextcloud.git roles/nextcloud~
+
+** Set up infrastructure for demo
+
+Create Centos 7 instance on Digital Ocean:
+
+#+begin_src bash 
+doctl compute droplet create nextcloud --size 2gb --image centos-7-x64 --region ams3 --ssh-keys <YOUR_KEYS>
+#+end_src
+
+Setup ansible hosts file 
+
+#+begin_src bash
+NODES=$(doctl compute droplet list | grep nextcloud | awk '{print $2" ansible_host="$3}')
+echo -e "[nextcloud]\n$NODES \n\n[all:vars]\nansible_user=root" > hosts
+#+end_src
+
+** Create Nextcloud on node
+
+Official [[https://docs.nextcloud.com/server/13/admin_manual/installation/index.html][Nextcloud documentation]]
+
+#+begin_src bash 
+ansible-playbook -i hosts nextcloud.yml
+#+end_src
+
+Customize options such as username/password domain in ~nextcloud.yml~ according to [[https://github.com/prgcont/ansible-nextcloud#role-variables][role variables documentation]].
+
+** Cleanup 
+
+#+begin_src bash
+doctl compute droplet delete nextcloud 
+#+end_src

--- a/07_ansible_operator/nextcloud.yml
+++ b/07_ansible_operator/nextcloud.yml
@@ -1,0 +1,3 @@
+- hosts: nextcloud
+  roles:
+      - { role: nextcloud, nextcloud_domain: nextcloud.prgcont.cz }


### PR DESCRIPTION
Initial version of ansible workshop: 
- chosen ansible role (https://github.com/prgcont/ansible-nextcloud)
- add Digital Ocean for demo 
- provides instructions to provision the instance and run ansible playbook